### PR TITLE
Use token-based booking flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -528,11 +528,11 @@
       showToast('エラー: '+e.message, 'err');
     };
 
-    // id_token があってトークン検証用APIが用意されている場合はそのまま uid 抽出済みなので通常予約を実行
+    // id_token を用いてサーバ側でユーザーIDを検証し予約を作成
     google.script.run
       .withSuccessHandler((r) => handleSuccess(r?.success !== undefined ? { ok: r.success, schedule: r.schedule } : r))
       .withFailureHandler(handleError)
-      .createBooking(iso, time, staff, name, '', phone, symptoms, uid);
+      .createBookingWithToken(payload, ID_TOKEN);
   }
   
   


### PR DESCRIPTION
## Summary
- Send booking requests using `createBookingWithToken` and pass the ID token
- Simplify booking handler to rely on server-side token verification

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1ac031d4832ab8e262f1da32edce