### PR TITLE
Add payload when verifying LINE token and allow LIFF origin

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -744,10 +744,14 @@ function cors_(out, status) {
 // LINE Login/ミニアプリのid_token検証
 function verifyIdToken_(idToken) {
   const url = 'https://api.line.me/oauth2/v2.1/verify';
+  const payload = { id_token: idToken, client_id: LINE_CHANNEL_ID };
   const res = UrlFetchApp.fetch(url, { method: 'post', payload, muteHttpExceptions: true });
   const code = res.getResponseCode();
   if (code !== 200) return null;
   const json = JSON.parse(res.getContentText() || '{}');
-  if (json && json.sub && json.aud === LINE_CHANNEL_ID) return json;
+  if (json && json.sub && json.aud === LINE_CHANNEL_ID) {
+    Logger.log('verifyIdToken_ success sub: ' + json.sub);
+    return json;
+  }
   return null;
 }

--- a/index.html
+++ b/index.html
@@ -260,6 +260,7 @@
   <script>
     // ===== Boot strap（単一の真実）=====
     const ALLOWED_ORIGINS = new Set([
+      'https://liff.line.me',
       'https://89center.net',
       'https://www.89center.net',
       'https://89center.studio.site' // 必要なら


### PR DESCRIPTION
## Summary
- send id token and client id in verifyIdToken_ payload
- log verified sub when token is valid
- allow messages from LIFF domain so ID tokens reach booking UI

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check code.gs` *(fails: Unknown file extension ".gs")*

------
https://chatgpt.com/codex/tasks/task_e_68ad1abdb4a4832abdf1dbcad24d4bfe