### PR TITLE
Add payload when verifying LINE token and allow LIFF origin

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -744,10 +744,14 @@ function cors_(out, status) {
 // LINE Login/ミニアプリのid_token検証
 function verifyIdToken_(idToken) {
   const url = 'https://api.line.me/oauth2/v2.1/verify';
+  const payload = { id_token: idToken, client_id: LINE_CHANNEL_ID };
   const res = UrlFetchApp.fetch(url, { method: 'post', payload, muteHttpExceptions: true });
   const code = res.getResponseCode();
   if (code !== 200) return null;
   const json = JSON.parse(res.getContentText() || '{}');
-  if (json && json.sub && json.aud === LINE_CHANNEL_ID) return json;
+  if (json && json.sub && json.aud === LINE_CHANNEL_ID) {
+    Logger.log('verifyIdToken_ success sub: ' + json.sub);
+    return json;
+  }
   return null;
 }

--- a/index.html
+++ b/index.html
@@ -260,6 +260,7 @@
   <script>
     // ===== Boot strap（単一の真実）=====
     const ALLOWED_ORIGINS = new Set([
+      'https://liff.line.me',
       'https://89center.net',
       'https://www.89center.net',
       'https://89center.studio.site' // 必要なら
@@ -481,8 +482,8 @@
         try { localStorage.setItem('LINE_UID', sub); } catch {}
       }
     }
-    // uid が無い場合はLINE連携待ち
-    if (!uid){
+    // id_token も uid も無い場合は連携待ち
+    if (!uid && !ID_TOKEN){
       showToast('LINE連携中です。数秒後にもう一度お試しください。','err');
       return;
     }
@@ -528,7 +529,16 @@
       showToast('エラー: '+e.message, 'err');
     };
 
-    // id_token があってトークン検証用APIが用意されている場合はそのまま uid 抽出済みなので通常予約を実行
+    // uid が無い場合は id_token をサーバー側で検証して予約
+    if (!uid){
+      google.script.run
+        .withSuccessHandler((r) => handleSuccess(r?.success !== undefined ? { ok: r.success, schedule: r.schedule } : r))
+        .withFailureHandler(handleError)
+        .createBookingWithToken(payload, ID_TOKEN);
+      return;
+    }
+
+    // uid が判明している場合は通常の予約処理
     google.script.run
       .withSuccessHandler((r) => handleSuccess(r?.success !== undefined ? { ok: r.success, schedule: r.schedule } : r))
       .withFailureHandler(handleError)


### PR DESCRIPTION
## Summary
- send id token and client id in verifyIdToken_ payload
- log verified sub when token is valid
- allow messages from LIFF domain so ID tokens reach booking UI
- fall back to server-side booking using ID token when UID not yet stored

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check code.gs` *(fails: Unknown file extension ".gs")*


------
https://chatgpt.com/codex/tasks/task_e_68ad1abdb4a4832abdf1dbcad24d4bfe